### PR TITLE
LuRecyclerView 没有 RefreshHeader，所以DataObserver 有关位置的地方不需要 +1

### DIFF
--- a/LRecyclerview_library/src/main/java/com/github/jdsjlzx/recyclerview/LuRecyclerView.java
+++ b/LRecyclerview_library/src/main/java/com/github/jdsjlzx/recyclerview/LuRecyclerView.java
@@ -167,17 +167,17 @@ public class LuRecyclerView extends RecyclerView {
 
         @Override
         public void onItemRangeChanged(int positionStart, int itemCount) {
-            mWrapAdapter.notifyItemRangeChanged(positionStart + mWrapAdapter.getHeaderViewsCount() + 1, itemCount);
+            mWrapAdapter.notifyItemRangeChanged(positionStart + mWrapAdapter.getHeaderViewsCount(), itemCount);
         }
 
         @Override
         public void onItemRangeInserted(int positionStart, int itemCount) {
-            mWrapAdapter.notifyItemRangeInserted(positionStart + mWrapAdapter.getHeaderViewsCount() + 1, itemCount);
+            mWrapAdapter.notifyItemRangeInserted(positionStart + mWrapAdapter.getHeaderViewsCount(), itemCount);
         }
 
         @Override
         public void onItemRangeRemoved(int positionStart, int itemCount) {
-            mWrapAdapter.notifyItemRangeRemoved(positionStart + mWrapAdapter.getHeaderViewsCount() + 1, itemCount);
+            mWrapAdapter.notifyItemRangeRemoved(positionStart + mWrapAdapter.getHeaderViewsCount(), itemCount);
             if(mWrapAdapter.getInnerAdapter().getItemCount() < mPageSize ) {
                 mFootView.setVisibility(GONE);
             }
@@ -187,7 +187,7 @@ public class LuRecyclerView extends RecyclerView {
         @Override
         public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
             int headerViewsCountCount = mWrapAdapter.getHeaderViewsCount();
-            mWrapAdapter.notifyItemRangeChanged(fromPosition + headerViewsCountCount + 1, toPosition + headerViewsCountCount + 1 + itemCount);
+            mWrapAdapter.notifyItemRangeChanged(fromPosition + headerViewsCountCount, toPosition + headerViewsCountCount + itemCount);
         }
 
     }


### PR DESCRIPTION
这个问题会导致删除等功能错位。